### PR TITLE
fix: add docker hub name

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -83,7 +83,7 @@ jobs:
               DB_HOST: localhost
               DB_PORT: 5432
             run: uv run pytest --cov=app tests/ --cov-report=html --cov-fail-under=80
-            
+
           # upload coverage report
           - name: Upload coverage report
             uses: actions/upload-artifact@v4
@@ -113,7 +113,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: practices/my-app:latest
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/my-app:latest
 
       
           


### PR DESCRIPTION
This pull request makes a small update to the CI/CD workflow configuration. The change updates the Docker image tag to use the Docker Hub username stored in secrets, ensuring images are pushed to the correct repository.
Closes #5 